### PR TITLE
Have code be mono font

### DIFF
--- a/lib/components/codeblock.dart
+++ b/lib/components/codeblock.dart
@@ -100,6 +100,7 @@ class _CodeblockState extends State<Codeblock> {
               maxLines: _collapse ? 5 : null,
               style: TextStyle(
                 color: Colors.grey[400],
+                fontFamily: 'monospace',
               ),
             ),
           ),


### PR DESCRIPTION
Give generated code monospaced font.

(I'll be honest - I made the change in GitHub web so I have NOT tried this change, but from the Flutter I remember, this should work.)